### PR TITLE
Update all runners to latest variants

### DIFF
--- a/.github/config/gha-test-macos.yml
+++ b/.github/config/gha-test-macos.yml
@@ -1,4 +1,4 @@
-name: macos-11
+name: macos-12
 channels:
   - conda-forge
 dependencies:

--- a/.github/config/gha-test-windows.yml
+++ b/.github/config/gha-test-windows.yml
@@ -1,4 +1,4 @@
-name: windows-2019
+name: windows-2022
 channels:
   - conda-forge
 dependencies:

--- a/.github/workflows/main_push_pull_request.yml
+++ b/.github/workflows/main_push_pull_request.yml
@@ -21,7 +21,7 @@ jobs:
         variant:
           - {os: ubuntu-22.04, cmake-preset: gha-test-ubuntu }
           - {os: macos-11, cmake-preset: gha-test-macos }
-          - {os: windows-2019, cmake-preset: gha-test-windows }
+          - {os: windows-2022, cmake-preset: gha-test-windows }
         python-version: ["3.10"]
         cmake-type: ['Release']
 

--- a/.github/workflows/main_push_pull_request.yml
+++ b/.github/workflows/main_push_pull_request.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         variant:
           - {os: ubuntu-22.04, cmake-preset: gha-test-ubuntu }
-          - {os: macos-11, cmake-preset: gha-test-macos }
+          - {os: macos-12, cmake-preset: gha-test-macos }
           - {os: windows-2022, cmake-preset: gha-test-windows }
         python-version: ["3.10"]
         cmake-type: ['Release']

--- a/.github/workflows/package_deploy.yml
+++ b/.github/workflows/package_deploy.yml
@@ -26,7 +26,7 @@ jobs:
         path: dist/*.tar.gz
 
   cibuildwheel:
-    name: Build ${{ matrix.python-tag }} ${{ matrix.variant.platform }} wheel on ${{ matrix.variant.os }}
+    name: ${{ matrix.python-tag }} ${{ matrix.variant.platform }} on ${{ matrix.variant.os }}
     runs-on: ${{ matrix.variant.os }}
     strategy:
       fail-fast: false
@@ -57,6 +57,7 @@ jobs:
         path: wheelhouse/*.whl
 
   buildwheel:
+    name: ${{ matrix.python-version }} ${{ matrix.variant.name }} on ${{ matrix.variant.os }}
     runs-on: ${{ matrix.variant.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/package_deploy.yml
+++ b/.github/workflows/package_deploy.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         variant:
-          - {os: windows-2019, name: "windows", config: "gha-test-windows"}
+          - {os: windows-2022, name: "windows", config: "gha-test-windows"}
         python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
     steps:
       - uses: brille/python-hdf5-buildwheel-action@v2.2

--- a/.github/workflows/package_deploy.yml
+++ b/.github/workflows/package_deploy.yml
@@ -34,7 +34,7 @@ jobs:
         variant:
           - {os: ubuntu-22.04, platform: 'manylinux'}
           - {os: ubuntu-22.04, platform: 'musllinux'}
-          - {os: macos-11, platform: 'macosx'}
+          - {os: macos-12, platform: 'macosx'}
         python-tag: ['cp36', 'cp37', 'cp38', 'cp39', 'cp310']
 
     steps:


### PR DESCRIPTION
The latest runner versions are listed [by GitHub](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) and are at this instant:
- windows-2022
- ubuntu-22.04
- macos-12

The actions should use the latest runners to put-off deprecation-based changes.