### PR TITLE
Rotate python versions for wheel building

### DIFF
--- a/.github/workflows/package_deploy.yml
+++ b/.github/workflows/package_deploy.yml
@@ -35,7 +35,7 @@ jobs:
           - {os: ubuntu-22.04, platform: 'manylinux'}
           - {os: ubuntu-22.04, platform: 'musllinux'}
           - {os: macos-12, platform: 'macosx'}
-        python-tag: ['cp36', 'cp37', 'cp38', 'cp39', 'cp310']
+        python-tag: ['cp37', 'cp38', 'cp39', 'cp310', 'cp311']
 
     steps:
     - uses: actions/checkout@v3
@@ -64,7 +64,7 @@ jobs:
       matrix:
         variant:
           - {os: windows-2022, name: "windows", config: "gha-test-windows"}
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
     steps:
       - uses: brille/python-hdf5-buildwheel-action@v2.2
         with:


### PR DESCRIPTION
Python 3.6 has been [beyon end-of-life](https://endoflife.date/python) for a year now. Other projects in the `brille` area have moved to newer versions of Python, so it is probably safe to stop supporting 3.6.

In the meantime Python 3.11 has been released and is gaining traction. Binaries for Python 3.11 and compatible numpy are available via conda-forge, so producing our own wheels for 3.11 should be possible.

- [x]  Remove Python 3.6 wheels
- [x] Add Python 3.11 wheels